### PR TITLE
 Matomo / stats gestion

### DIFF
--- a/app/assets/stylesheets/pages/_help_index.scss
+++ b/app/assets/stylesheets/pages/_help_index.scss
@@ -130,6 +130,7 @@
         border: solid 1px $black;
         padding: 12px 0;
         border-radius: 4px;
+        margin-top: 0;
       }
       .result-search-mobile-div {
         padding: 4%;

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,6 +1,7 @@
 @import "home";
 @import "help_show";
 @import "help_index";
+@import "static_pages";
 @import "stats";
 @import "conseils_pratiques";
 @import "conseils_videos_show";

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,4 +9,7 @@ class PagesController < ApplicationController
 
   def a_propos
   end
+
+  def donnees_personelles
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,14 @@
     <link href="https://fonts.googleapis.com/css2?family=Spectral:ital@1&display=swap" rel="stylesheet">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+    <!-- Matomo Tag Manager -->
+    <script>
+    var _mtm = window._mtm = window._mtm || [];
+    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src='https://stats.data.gouv.fr/js/container_IXjnThWx.js'; s.parentNode.insertBefore(g,s);
+    </script>
+    <!-- End Matomo Tag Manager -->
     <script>
       var _paq = window._paq = window._paq || [];
       /* tracker methods like "setCustomDimension" should be called before "trackPageView" */

--- a/app/views/pages/donnees_personelles.html.erb
+++ b/app/views/pages/donnees_personelles.html.erb
@@ -1,0 +1,4 @@
+  <iframe
+    style="border: 0; height: 200px; width: 600px;"
+    src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=16px&fontFamily=Marianne-Regular"
+    ></iframe>

--- a/app/views/pages/stats.html.erb
+++ b/app/views/pages/stats.html.erb
@@ -3,7 +3,7 @@
   <h2 class="mt20 mb0">Visites</h2>
   <div>
     <p class="main-paragraphe text-align-left">Nombre de visites depuis le début du service</p>
-    <iframe width="100%" height="70" src="https://stats.data.gouv.fr/index.php?module=Widgetize&action=iframe&column=&disableLink=0&widget=1&moduleToWidgetize=CoreVisualizations&actionToWidgetize=singleMetricView&idSite=187&period=range&date=previous30&disableLink=1&widget=1" scrolling="yes" frameborder="0" marginheight="0" marginwidth="0"></iframe>
+    <iframe width="100%" height="150" src="https://stats.data.gouv.fr/index.php?module=Widgetize&action=iframe&column=&disableLink=0&widget=1&moduleToWidgetize=CoreVisualizations&actionToWidgetize=singleMetricView&idSite=187&period=range&date=previous260&disableLink=1&widget=1" scrolling="yes" frameborder="0" marginheight="0" marginwidth="0"></iframe>
     <p class="main-paragraphe text-align-left">Évolution des visites ces 30 derniers jours</p>
     <iframe width="100%" height="280" src="https://stats.data.gouv.fr/index.php?module=Widgetize&action=iframe&forceView=1&viewDataTable=graphEvolution&disableLink=0&widget=1&moduleToWidgetize=VisitsSummary&actionToWidgetize=getEvolutionGraph&idSite=187&period=range&date=previous30&disableLink=1&widget=1" scrolling="yes" frameborder="0" marginheight="0" marginwidth="0"></iframe>
   </div>
@@ -13,7 +13,7 @@
       <p class="stats-number"><%= Help.count %></p>
     </div>
     <p class="main-paragraphe text-align-left"><span class="stats-pourcentage"><%= NotationCatalogue.pourcentage_notation_help_utile %>%</span> d'utilisatrices ont jugé le catalogue d'aides <span class="stats-pourcentage">utile</span> et se déclarent prêtes à candidater</p>
-    <p class="main-paragraphe text-align-left"><span class="stats-pourcentage"><%= NotationCatalogue.pourcentage_notation_help_utile_mais_fermee %>%</span> d'utilisatrices ont jugé le catalogue d'aides <span class="stats-pourcentage">n'ont pas trouvé d'aides ouvertes correspondant à leurs besoins</span></p>
+    <p class="main-paragraphe text-align-left"><span class="stats-pourcentage"><%= NotationCatalogue.pourcentage_notation_help_utile_mais_fermee %>%</span> d'utilisatrices n'ont pas trouvé <span class="stats-pourcentage">d'aides ouvertes correspondant à leurs besoins</span></p>
     <p class="main-paragraphe text-align-left"><span class="stats-pourcentage"><%= NotationCatalogue.pourcentage_notation_help_inutile %>%</span> d'utilisatrices ont jugé le catalogue d'aides <span class="stats-pourcentage">inutile</span></p>
   <h2 class="mt20 mb0">Conseils & témoignages</h2>
     <div class="flex-div-left">
@@ -32,4 +32,9 @@
       <%= line_chart ConseilsVideo.group_by_month(:created_at).count, xtitle: "Mois", ytitle: "Conseils Vidéos" %>
     </div>
   </div>
+  <iframe
+    style="border: 0; height: 150px; width: 600px;"
+    src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=16px&fontFamily=Marianne-Regular"
+    ></iframe>
+
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -13,8 +13,8 @@
       <hr class="vl">
       <%= link_to "Gestion des cookies", "#" %>
       <hr class="vl">
-      <%= link_to "Statistiques", "#" %>
+      <%= link_to "Statistiques", stats_path %>
     </div>
-    <p>Sauf mention contraire, tous les textes de ce site sont sous <a href="#" class="license">licence etatlab-2.0</a> <%= image_tag "icone-download.svg" %></p>
+    <p>Sauf mention contraire, tous les textes de ce site sont sous <a href="https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf" class="license">licence etatlab-2.0</a> <%= image_tag "icone-download.svg" %></p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'pages#home'
   get "mentions_legales", to: 'pages#mentions_legales'
+  get "donnees_personelles", to: 'pages#donnees_personelles'
   get "a_propos", to: 'pages#a_propos'
   get "stats", to: 'pages#stats'
   resources :contacts, only: :create


### PR DESCRIPTION
- Ajouter l'opt out de matomo sur la page stats en bas + dans la page donnees personnelles
-  Revoir le chiffre de nombre de visites totales
-  Ajouter le lien stats sur le footer
-  Ajouter des marges dans les pages footer
-  Typo a revoir page stats
-  Ajouter lien etalab footer